### PR TITLE
Remove scroll animation for z* command due to flickering

### DIFF
--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -69,13 +69,13 @@ endif
 
 " Map some of the z commands similarly.
 if maparg("zt", 'n') == ''
-  nnoremap zt zt:call <SID>CheckForChange(1)<CR>
+  nnoremap zt zt:call <SID>CheckForChange(0)<CR>
 endif
 if maparg("zz", 'n') == ''
-  nnoremap zz zz:call <SID>CheckForChange(1)<CR>
+  nnoremap zz zz:call <SID>CheckForChange(0)<CR>
 endif
 if maparg("zb", 'n') == ''
-  nnoremap zb zb:call <SID>CheckForChange(1)<CR>
+  nnoremap zb zb:call <SID>CheckForChange(0)<CR>
 endif
 
 


### PR DESCRIPTION
The current setting makes z* command flickering when navigating via z* command. It could be caused by vim renders the target view at fist then rollback to start view and redraw animations to target view, then showing the target view at first causes flickering.  But we still need update the last saved view after z* command even if we don't do scrolling, or the following scroll will be very weird.