### PR TITLE
Option to disable autocommands

### DIFF
--- a/doc/sexy_scroller.txt
+++ b/doc/sexy_scroller.txt
@@ -97,7 +97,8 @@ The following exposed function is available for other scripts to call:
 
     g:SexyScroller_ScrollToCursor(...)
 
-To use the globally exposed function it is useful to disable the cursor movement related autocommands:
+To use the globally exposed function it is useful to disable the cursor
+movement related autocommands:
 
     :let g:SexyScroller_AutocmdsEnabled = 0
 

--- a/doc/sexy_scroller.txt
+++ b/doc/sexy_scroller.txt
@@ -93,12 +93,9 @@ able to reduce the issue by configuring the minimum thresholds:
 If the cursor or the window move less than these distances, SexyScroller will
 not engage.
 
-The following exposed function is available for other scripts to call:
-
-    g:SexyScroller_ScrollToCursor(...)
-
-To use the globally exposed function it is useful to disable the cursor
-movement related autocommands:
+The function g:SexyScroller_ScrollToCursor(...) is available as a globally
+exposed function. If you want to use this, it is useful to disable the
+cursor movement related autocommands:
 
     :let g:SexyScroller_AutocmdsEnabled = 0
 

--- a/doc/sexy_scroller.txt
+++ b/doc/sexy_scroller.txt
@@ -93,6 +93,14 @@ able to reduce the issue by configuring the minimum thresholds:
 If the cursor or the window move less than these distances, SexyScroller will
 not engage.
 
+The following exposed function is available for other scripts to call:
+
+    g:SexyScroller_ScrollToCursor(...)
+
+To use the globally exposed function it is useful to disable the cursor movement related autocommands:
+
+    :let g:SexyScroller_AutocmdsEnabled = 0
+
 
 # Issues
 

--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -64,38 +64,6 @@ endif
 
 command! SexyScrollerToggle call s:ToggleEnabled()
 
-" OLD approach
-" function! s:Toggle_Smooth_Scroller_Autocmd()
-"     if g:SexyScroller_AutocmdsEnabled == 1
-"         if !exists('#Smooth_Scroller')
-"             augroup Smooth_Scroller
-"               autocmd!
-"               autocmd CursorMoved * call s:CheckForChange(1)
-"               autocmd CursorMovedI * call s:CheckForChange(1)
-"               autocmd InsertLeave * call s:CheckForChange(0)
-"               " Unfortunately we would like to fire on other occasions too, e.g.
-"               " BufferScrolled, but Vim does not offer enough events for us to hook to!
-"             augroup END
-"
-"             " doautoall Smooth_Scroller
-"             " echo 'Smooth_Scroller autocmd enabled'
-"         endif
-"     else
-"         if exists('#Smooth_Scroller')
-"             silent! autocmd! Smooth_Scroller
-"             echo 'Smooth Scroller autocmd disabled'
-"         endif
-"     endif
-" endfunction
-"
-" augroup Init_Autocmd
-"   autocmd!
-"   autocmd VimEnter * call s:Toggle_Smooth_Scroller_Autocmd()
-"   autocmd SourceCmd $MYVIMRC source $MYVIMRC |
-"               \ call s:Toggle_Smooth_Scroller_Autocmd() |
-"               \ AirlineRefresh  " this is needed to fix Airline colors
-" augroup END
-
 augroup Smooth_Scroller
   autocmd!
   " Wrap all commands (need to pass as strings) with the cmd wrapper so that they can be
@@ -109,15 +77,6 @@ augroup Smooth_Scroller
   " Unfortunately we would like to fire on other occasions too, e.g.
   " BufferScrolled, but Vim does not offer enough events for us to hook to!
 augroup END
-
-
-" Wrapper around the command to run it conditionally based on a boolean argument
-function! s:AutocmdCmdWrapper(cmd, run)
-    if a:run == 1
-        execute a:cmd
-    endif
-endfunction
-
 
 " |CTRL-E| and |CTRL-Y| scroll the window, but do not fire any events for us to detect.
 " If the user has not made a custom mapping for them, we will map them to fix this.
@@ -320,6 +279,13 @@ endfunction
 function! s:ToggleEnabled()
   let g:SexyScroller_Enabled = !g:SexyScroller_Enabled
   echo "Sexy Scroller is " . ( g:SexyScroller_Enabled ? "en" : "dis" ) . "abled"
+endfunction
+
+" Conditionally run a command
+function! s:AutocmdCmdWrapper(cmd, run)
+    if a:run == 1
+        execute a:cmd
+    endif
 endfunction
 
 

--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -68,9 +68,9 @@ augroup Smooth_Scroller
   autocmd!
   " Wrap all commands (as strings) with the cmd wrapper so they can be
   " turned on or off with the g:SexyScroller_AutcmdsEnabled option
-  autocmd CursorMoved * call s:AutocmdCmdWrapper("call s:CheckForChange(1)", g:SexyScroller_AutocmdsEnabled)
-  autocmd CursorMovedI * call s:AutocmdCmdWrapper("call s:CheckForChange(1)", g:SexyScroller_AutocmdsEnabled)
-  autocmd InsertLeave * call s:AutocmdCmdWrapper("call s:CheckForChange(0)", g:SexyScroller_AutocmdsEnabled)
+  autocmd CursorMoved * call s:AutocmdCmdWrapper("call s:CheckForChange(1)")
+  autocmd CursorMovedI * call s:AutocmdCmdWrapper("call s:CheckForChange(1)")
+  autocmd InsertLeave * call s:AutocmdCmdWrapper("call s:CheckForChange(0)")
   " Unfortunately we would like to fire on other occasions too, e.g.
   " BufferScrolled, but Vim does not offer enough events for us to hook to!
 augroup END
@@ -279,8 +279,8 @@ function! s:ToggleEnabled()
 endfunction
 
 " Conditionally run a command
-function! s:AutocmdCmdWrapper(cmd, run)
-    if a:run == 1
+function! s:AutocmdCmdWrapper(cmd)
+    if g:SexyScroller_AutocmdsEnabled == 1
         execute a:cmd
     endif
 endfunction

--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -68,12 +68,9 @@ augroup Smooth_Scroller
   autocmd!
   " Wrap all commands (as strings) with the cmd wrapper so they can be
   " turned on or off with the g:SexyScroller_AutcmdsEnabled option
-  autocmd CursorMoved * call s:AutocmdCmdWrapper("call s:CheckForChange(1)",
-                                                  \g:SexyScroller_AutocmdsEnabled)
-  autocmd CursorMovedI * call s:AutocmdCmdWrapper("call s:CheckForChange(1)",
-                                                  \g:SexyScroller_AutocmdsEnabled)
-  autocmd InsertLeave * call s:AutocmdCmdWrapper("call s:CheckForChange(0)",
-                                                 \g:SexyScroller_AutocmdsEnabled)
+  autocmd CursorMoved * call s:AutocmdCmdWrapper("call s:CheckForChange(1)", g:SexyScroller_AutocmdsEnabled)
+  autocmd CursorMovedI * call s:AutocmdCmdWrapper("call s:CheckForChange(1)", g:SexyScroller_AutocmdsEnabled)
+  autocmd InsertLeave * call s:AutocmdCmdWrapper("call s:CheckForChange(0)", g:SexyScroller_AutocmdsEnabled)
   " Unfortunately we would like to fire on other occasions too, e.g.
   " BufferScrolled, but Vim does not offer enough events for us to hook to!
 augroup END

--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -66,8 +66,8 @@ command! SexyScrollerToggle call s:ToggleEnabled()
 
 augroup Smooth_Scroller
   autocmd!
-  " Wrap all commands (need to pass as strings) with the cmd wrapper so that they can be
-  " deactivated with the g:SexyScroller_AutcmdsEnabled flag
+  " Wrap all commands (as strings) with the cmd wrapper so they can be
+  " turned on or off with the g:SexyScroller_AutcmdsEnabled option
   autocmd CursorMoved * call s:AutocmdCmdWrapper("call s:CheckForChange(1)",
                                                   \g:SexyScroller_AutocmdsEnabled)
   autocmd CursorMovedI * call s:AutocmdCmdWrapper("call s:CheckForChange(1)",


### PR DESCRIPTION
I think it may be useful to have an option to disable the cursor autocommands, for example if you
want to use the exposed scroll function, so I've added this option. It does require all the commands
in the autocmd block to be wrapped with another function; it's the easiest way I found to make this
work without needing to restart VIM or anything like that. Let me know what you think.