### PR TITLE
fix: unset lazy redraw after we have finished scrolling

### DIFF
--- a/plugin/sexy_scroller.vim
+++ b/plugin/sexy_scroller.vim
@@ -249,6 +249,7 @@ function! s:smooth_scroll(start, end)
       " If we do end up resuming this animation, this winrestview will cause flicker, unless we set lazyredraw to prevent it.
       set lazyredraw
       call winrestview(a:end)
+      set lazyredraw&
       return 0
       " Old approach:
       "let w:oldPosition = current


### PR DESCRIPTION
plugins like noice.nvim will throw errors if lazyredraw is always enabled